### PR TITLE
Add explicit dependency on ffmpeg

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -14,6 +14,8 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+ffmpeg:
+- '4.4'
 jpeg:
 - '9'
 libopencv:
@@ -21,18 +23,11 @@ libopencv:
 libpng:
 - '1.6'
 pin_run_as_build:
-  jpeg:
-    max_pin: x
-  libpng:
-    max_pin: x.x
   python:
     min_pin: x.x
     max_pin: x.x
-  sqlite:
-    max_pin: x
 python:
 - 3.10.* *_cpython
-- 3.7.* *_cpython
 - 3.8.* *_cpython
 - 3.9.* *_cpython
 qt_main:

--- a/.ci_support/migrations/libopencv460.yaml
+++ b/.ci_support/migrations/libopencv460.yaml
@@ -1,8 +1,0 @@
-migrator_ts: 1661815782
-__migrator:
-  kind: version
-  migration_number: 1
-  bump_number: 1
-
-libopencv:
-  - 4.6.0

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -12,6 +12,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '14'
+ffmpeg:
+- '4.4'
 jpeg:
 - '9'
 libopencv:
@@ -21,18 +23,11 @@ libpng:
 macos_machine:
 - x86_64-apple-darwin13.4.0
 pin_run_as_build:
-  jpeg:
-    max_pin: x
-  libpng:
-    max_pin: x.x
   python:
     min_pin: x.x
     max_pin: x.x
-  sqlite:
-    max_pin: x
 python:
 - 3.10.* *_cpython
-- 3.7.* *_cpython
 - 3.8.* *_cpython
 - 3.9.* *_cpython
 qt_main:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -6,6 +6,8 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2019
+ffmpeg:
+- '4.4'
 jpeg:
 - '9'
 libopencv:
@@ -13,18 +15,11 @@ libopencv:
 libpng:
 - '1.6'
 pin_run_as_build:
-  jpeg:
-    max_pin: x
-  libpng:
-    max_pin: x.x
   python:
     min_pin: x.x
     max_pin: x.x
-  sqlite:
-    max_pin: x
 python:
 - 3.10.* *_cpython
-- 3.7.* *_cpython
 - 3.8.* *_cpython
 - 3.9.* *_cpython
 qt_main:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: bf16e70b26e9b33323e17c4a298499e50299641a7c384904b331f2fb247c84cf
 
 build:
-  number: 1
+  number: 2
 
 outputs:
   - name: {{ namecxx }}
@@ -61,6 +61,7 @@ outputs:
         - libopencv
         - portaudio
         - qt-main
+        - ffmpeg
 
       run:
         # ycm and eigen are mentioned in the headers so needed when building


### PR DESCRIPTION
YARP already depends on ffmpeg via opencv, but this dependency is not tracked, even if it is enabled automatically. This PR fixes the situation (see https://github.com/robotology/robotology-superbuild/issues/1296#issuecomment-1293913775). Note that we are not enabling all the devices that depend on ffmpeg due to https://github.com/robotology/yarp/issues/2885 .

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
