### PR TITLE
Rebuild to avoid bug in generated CMake config files due to CMake 3.26.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - fixpypy.patch
 
 build:
-  number: 1
+  number: 2
 
 outputs:
   - name: {{ namecxx }}


### PR DESCRIPTION
Previous packages were generated with CMake 3.26.0 that had the problem fixed in https://gitlab.kitware.com/cmake/cmake/-/merge_requests/8337/diffs . Rebuilding we avoid the problem as CMake 3.26.1 fixed the issue.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
