### PR TITLE
Update yarp to 3.9.0 and rename yarp-cxx to libyarp and keep yarp-cxx compatibility package

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -33,6 +33,9 @@ jobs:
 
   - script: |
         export CI=azure
+        export flow_run_id=azure_$(Build.BuildNumber).$(System.JobAttempt)
+        export remote_url=$(Build.Repository.Uri)
+        export sha=$(Build.SourceVersion)
         export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
         export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
         if [[ "${BUILD_REASON:-}" == "PullRequest" ]]; then

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -20,6 +20,9 @@ jobs:
   # TODO: Fast finish on azure pipelines?
   - script: |
       export CI=azure
+      export flow_run_id=azure_$(Build.BuildNumber).$(System.JobAttempt)
+      export remote_url=$(Build.Repository.Uri)
+      export sha=$(Build.SourceVersion)
       export OSX_FORCE_SDK_DOWNLOAD="1"
       export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
       export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -42,6 +42,9 @@ jobs:
         PYTHONUNBUFFERED: 1
         CONFIG: $(CONFIG)
         CI: azure
+        flow_run_id: azure_$(Build.BuildNumber).$(System.JobAttempt)
+        remote_url: $(Build.Repository.Uri)
+        sha: $(Build.SourceVersion)
         UPLOAD_PACKAGES: $(UPLOAD_PACKAGES)
         UPLOAD_TEMP: $(UPLOAD_TEMP)
         BINSTAR_TOKEN: $(BINSTAR_TOKEN)

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -28,13 +28,15 @@ conda-build:
 pkgs_dirs:
   - ${FEEDSTOCK_ROOT}/build_artifacts/pkg_cache
   - /opt/conda/pkgs
+solver: libmamba
 
 CONDARC
+export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 mamba install --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup=3
+    pip mamba conda-build boa conda-forge-ci-setup=4
 mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup=3
+    pip mamba conda-build boa conda-forge-ci-setup=4
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
@@ -55,6 +57,12 @@ if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
   cp "${FEEDSTOCK_ROOT}/LICENSE.txt" "${RECIPE_ROOT}/recipe-scripts-license.txt"
 fi
 
+if [[ "${sha:-}" == "" ]]; then
+  pushd ${FEEDSTOCK_ROOT}
+  sha=$(git rev-parse HEAD)
+  popd
+fi
+
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
         EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
@@ -68,7 +76,8 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
 else
     conda mambabuild "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
+        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
+        --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"
     ( startgroup "Validating outputs" ) 2> /dev/null
 
     validate_recipe_outputs "${FEEDSTOCK_NAME}"

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -91,6 +91,9 @@ docker run ${DOCKER_RUN_ARGS} \
            -e CPU_COUNT \
            -e BUILD_WITH_CONDA_DEBUG \
            -e BUILD_OUTPUT_ID \
+           -e flow_run_id \
+           -e remote_url \
+           -e sha \
            -e BINSTAR_TOKEN \
            -e FEEDSTOCK_TOKEN \
            -e STAGING_BINSTAR_TOKEN \

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -22,11 +22,13 @@ bash $MINIFORGE_FILE -b -p ${MINIFORGE_HOME}
 
 source ${MINIFORGE_HOME}/etc/profile.d/conda.sh
 conda activate base
+export CONDA_SOLVER="libmamba"
+export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 mamba install --update-specs --quiet --yes --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup=3
+    pip mamba conda-build boa conda-forge-ci-setup=4
 mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup=3
+    pip mamba conda-build boa conda-forge-ci-setup=4
 
 
 
@@ -43,6 +45,10 @@ if [[ "${CI:-}" != "" ]]; then
   /usr/bin/sudo -k
 else
   echo -e "\n\nNot mangling homebrew as we are not running in CI"
+fi
+
+if [[ "${sha:-}" == "" ]]; then
+  sha=$(git rev-parse HEAD)
 fi
 
 echo -e "\n\nRunning the build setup script."
@@ -77,7 +83,8 @@ else
 
     conda mambabuild ./recipe -m ./.ci_support/${CONFIG}.yaml \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
+        --clobber-file ./.ci_support/clobber_${CONFIG}.yaml \
+        --extra-meta flow_run_id="$flow_run_id" remote_url="$remote_url" sha="$sha"
     ( startgroup "Validating outputs" ) 2> /dev/null
 
     validate_recipe_outputs "${FEEDSTOCK_NAME}"

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -17,10 +17,14 @@ call :start_group "Configuring conda"
 
 :: Activate the base conda environment
 call activate base
+:: Configure the solver
+set "CONDA_SOLVER=libmamba"
+if !errorlevel! neq 0 exit /b !errorlevel!
+set "CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1"
 
 :: Provision the necessary dependencies to build the recipe later
 echo Installing dependencies
-mamba.exe install "python=3.10" pip mamba conda-build boa conda-forge-ci-setup=3 -c conda-forge --strict-channel-priority --yes
+mamba.exe install "python=3.10" pip mamba conda-build boa conda-forge-ci-setup=4 -c conda-forge --strict-channel-priority --yes
 if !errorlevel! neq 0 exit /b !errorlevel!
 
 :: Set basic configuration
@@ -38,7 +42,13 @@ if EXIST LICENSE.txt (
     copy LICENSE.txt "recipe\\recipe-scripts-license.txt"
 )
 if NOT [%HOST_PLATFORM%] == [%BUILD_PLATFORM%] (
-    set "EXTRA_CB_OPTIONS=%EXTRA_CB_OPTIONS% --no-test"
+    if [%CROSSCOMPILING_EMULATOR%] == [] (
+        set "EXTRA_CB_OPTIONS=%EXTRA_CB_OPTIONS% --no-test"
+    )
+)
+
+if NOT [%flow_run_id%] == [] (
+    set "EXTRA_CB_OPTIONS=%EXTRA_CB_OPTIONS% --extra-meta flow_run_id=%flow_run_id% remote_url=%remote_url% sha=%sha%"
 )
 
 call :end_group

--- a/README.md
+++ b/README.md
@@ -3,6 +3,19 @@ About yarp-feedstock
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/yarp-feedstock/blob/main/LICENSE.txt)
 
+
+About yarp
+----------
+
+Home: https://github.com/robotology/yarp
+
+Package license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
+
+Summary: YARP is a library and toolkit for communication and device interfaces, used on everything from humanoids to embedded devices.
+
+About yarp-cxx
+--------------
+
 Home: https://github.com/robotology/yarp
 
 Package license: BSD-3-Clause AND MIT AND GPL-3.0-or-later
@@ -81,6 +94,7 @@ Current release info
 
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-libyarp-green.svg)](https://anaconda.org/conda-forge/libyarp) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libyarp.svg)](https://anaconda.org/conda-forge/libyarp) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libyarp.svg)](https://anaconda.org/conda-forge/libyarp) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libyarp.svg)](https://anaconda.org/conda-forge/libyarp) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-yarp-green.svg)](https://anaconda.org/conda-forge/yarp) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/yarp.svg)](https://anaconda.org/conda-forge/yarp) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/yarp.svg)](https://anaconda.org/conda-forge/yarp) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/yarp.svg)](https://anaconda.org/conda-forge/yarp) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-yarp--cxx-green.svg)](https://anaconda.org/conda-forge/yarp-cxx) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/yarp-cxx.svg)](https://anaconda.org/conda-forge/yarp-cxx) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/yarp-cxx.svg)](https://anaconda.org/conda-forge/yarp-cxx) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/yarp-cxx.svg)](https://anaconda.org/conda-forge/yarp-cxx) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-yarp--python-green.svg)](https://anaconda.org/conda-forge/yarp-python) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/yarp-python.svg)](https://anaconda.org/conda-forge/yarp-python) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/yarp-python.svg)](https://anaconda.org/conda-forge/yarp-python) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/yarp-python.svg)](https://anaconda.org/conda-forge/yarp-python) |
@@ -95,41 +109,41 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `yarp, yarp-cxx, yarp-python` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `libyarp, yarp, yarp-cxx, yarp-python` can be installed with `conda`:
 
 ```
-conda install yarp yarp-cxx yarp-python
-```
-
-or with `mamba`:
-
-```
-mamba install yarp yarp-cxx yarp-python
-```
-
-It is possible to list all of the versions of `yarp` available on your platform with `conda`:
-
-```
-conda search yarp --channel conda-forge
+conda install libyarp yarp yarp-cxx yarp-python
 ```
 
 or with `mamba`:
 
 ```
-mamba search yarp --channel conda-forge
+mamba install libyarp yarp yarp-cxx yarp-python
+```
+
+It is possible to list all of the versions of `libyarp` available on your platform with `conda`:
+
+```
+conda search libyarp --channel conda-forge
+```
+
+or with `mamba`:
+
+```
+mamba search libyarp --channel conda-forge
 ```
 
 Alternatively, `mamba repoquery` may provide more information:
 
 ```
 # Search all versions available on your platform:
-mamba repoquery search yarp --channel conda-forge
+mamba repoquery search libyarp --channel conda-forge
 
-# List packages depending on `yarp`:
-mamba repoquery whoneeds yarp --channel conda-forge
+# List packages depending on `libyarp`:
+mamba repoquery whoneeds libyarp --channel conda-forge
 
-# List dependencies of `yarp`:
-mamba repoquery depends yarp --channel conda-forge
+# List dependencies of `libyarp`:
+mamba repoquery depends libyarp --channel conda-forge
 ```
 
 
@@ -151,7 +165,7 @@ available continuous integration services. Thanks to the awesome service provide
 [CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/),
 [Drone](https://cloud.drone.io/welcome), and [TravisCI](https://travis-ci.com/)
 it is possible to build and upload installable packages to the
-[conda-forge](https://anaconda.org/conda-forge) [Anaconda-Cloud](https://anaconda.org/)
+[conda-forge](https://anaconda.org/conda-forge) [anaconda.org](https://anaconda.org/)
 channel for Linux, Windows and OSX respectively.
 
 To manage the continuous integration and simplify feedstock maintenance

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     - 2983.patch
 
 build:
-  number: 7
+  number: 0
 
 outputs:
   - name: {{ namecxx }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "yarp" %}
-{% set namecxx = "yarp-cxx" %}
+{% set namecxx = "libyarp" %}
 {% set namepython = "yarp-python" %}
-{% set version = "3.8.1" %}
+{% set version = "3.9.0" %}
 
 package:
   name: {{ name }}
@@ -9,7 +9,7 @@ package:
 
 source:
   url: https://github.com/robotology/yarp/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 2fafadcd2a965d3c0e4d683cd2748277565c67db6a4acd4a435b4122cba2d749
+  sha256: 3691c12a522e246ea506866df99a30b0d2c50d5c5efde602e7e207cd5dd7a4e2
   patches:
     - fixpypy.patch
     - 2983.patch
@@ -66,7 +66,7 @@ outputs:
 
       run:
         # ycm and eigen are mentioned in the headers so needed when building
-        # against yarp-cxx
+        # against libyarp
         - ycm-cmake-modules
         - eigen
 
@@ -124,6 +124,17 @@ outputs:
     test:
       imports:
         - yarp
+
+  - name: yarp-cxx
+    build:
+      run_exports:
+        - {{ pin_subpackage(namecxx, max_pin='x.x.x') }}
+    requirements:
+      run:
+        - {{ pin_subpackage(namecxx, exact=True) }}
+    test:
+      commands:
+        - yarp help
 
 about:
   home: https://github.com/robotology/yarp


### PR DESCRIPTION
For consistency with other packages in conda-forge, it is useful to rename yarp-cxx to libyarp. 
However, to do so we need to wait for the next patch release of yarp. Anyhow, I already opened the PR to remember this.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
