### PR TITLE
Set ENABLE_yarppm_bottle_compression_zlib, ENABLE_yarppm_depthimage_compression_zlib and ENABLE_yarppm_image_compression_ffmpeg CMake options

### DIFF
--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -60,7 +60,10 @@ jobs:
         if EXIST LICENSE.txt (
           copy LICENSE.txt "recipe\\recipe-scripts-license.txt"
         )
-        conda.exe mambabuild "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables
+        if NOT [%HOST_PLATFORM%] == [%BUILD_PLATFORM%] (
+          set "EXTRA_CB_OPTIONS=%EXTRA_CB_OPTIONS% --no-test"
+        )
+        conda.exe mambabuild "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables %EXTRA_CB_OPTIONS%
       displayName: Build recipe
       env:
         PYTHONUNBUFFERED: 1

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -55,11 +55,6 @@ source run_conda_forge_build_setup
 echo -e "\n\nMaking the build clobber file"
 make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
 
-if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
-    EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
-fi
-
-
 if [[ -f LICENSE.txt ]]; then
   cp LICENSE.txt "recipe/recipe-scripts-license.txt"
 fi
@@ -75,6 +70,11 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     # Drop into an interactive shell
     /bin/bash
 else
+
+    if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
+        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+    fi
+
     conda mambabuild ./recipe -m ./.ci_support/${CONFIG}.yaml \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file ./.ci_support/clobber_${CONFIG}.yaml

--- a/recipe/bld_cxx.bat
+++ b/recipe/bld_cxx.bat
@@ -17,6 +17,9 @@ cmake -G "Ninja" ^
     -DENABLE_yarpcar_bayer:BOOL=ON ^
     -DENABLE_yarpcar_mjpeg:BOOL=ON ^
     -DENABLE_yarpcar_portmonitor:BOOL=ON ^
+    -DENABLE_yarppm_bottle_compression_zlib:BOOL=ON ^
+    -DENABLE_yarppm_depthimage_compression_zlib:BOOL=ON ^
+    -DENABLE_yarppm_image_compression_ffmpeg:BOOL=ON ^
     -DENABLE_yarppm_depthimage_to_mono:BOOL=ON ^
     -DENABLE_yarppm_depthimage_to_rgb:BOOL=ON ^
     -DENABLE_yarpidl_thrift:BOOL=ON ^

--- a/recipe/build_cxx.sh
+++ b/recipe/build_cxx.sh
@@ -42,6 +42,9 @@ cmake ${CMAKE_ARGS} -GNinja .. \
     -DENABLE_yarpcar_bayer:BOOL=ON \
     -DENABLE_yarpcar_mjpeg:BOOL=ON \
     -DENABLE_yarpcar_portmonitor:BOOL=ON \
+    -DENABLE_yarppm_bottle_compression_zlib:BOOL=ON \
+    -DENABLE_yarppm_depthimage_compression_zlib:BOOL=ON \
+    -DENABLE_yarppm_image_compression_ffmpeg:BOOL=ON \
     -DENABLE_yarppm_depthimage_to_mono:BOOL=ON \
     -DENABLE_yarppm_depthimage_to_rgb:BOOL=ON \
     -DENABLE_yarpidl_thrift:BOOL=ON \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     - 2983.patch
 
 build:
-  number: 2
+  number: 3
 
 outputs:
   - name: {{ namecxx }}


### PR DESCRIPTION
Set this options that are useful for compressing generic data, depth images and RGB images sent over YARP ports, as suggested by @andreaRosasco . 

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
