### PR TITLE
Fix error in pip metadata that listed version as 3.9.0~dev instead of simplfy 3.9.0

### DIFF
--- a/recipe/3097.patch
+++ b/recipe/3097.patch
@@ -1,0 +1,18 @@
+diff --git a/bindings/python/CMakeLists.txt b/bindings/python/CMakeLists.txt
+index 20ea4390ac8..a98282717fd 100644
+--- a/bindings/python/CMakeLists.txt
++++ b/bindings/python/CMakeLists.txt
+@@ -92,11 +92,11 @@ if(YARP_PYTHON_PIP_METADATA_INSTALL)
+   file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/METADATA "")
+   file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/METADATA "Metadata-Version: 2.1\n")
+   file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/METADATA "Name: yarp\n")
+-  file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/METADATA "Version: ${YARP_VERSION}\n")
++  file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/METADATA "Version: ${YARP_VERSION_SHORT}\n")
+   file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/INSTALLER "${YARP_PYTHON_PIP_METADATA_INSTALLER}\n")
+   install(
+     FILES "${CMAKE_CURRENT_BINARY_DIR}/METADATA" "${CMAKE_CURRENT_BINARY_DIR}/INSTALLER"
+-    DESTINATION ${CMAKE_INSTALL_PYTHON3DIR}/yarp-${YARP_VERSION}.dist-info)
++    DESTINATION ${CMAKE_INSTALL_PYTHON3DIR}/yarp-${YARP_VERSION_SHORT}.dist-info)
+ endif()
+ 
+ if(YARP_COMPILE_TESTS)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,7 @@ source:
   patches:
     - fixpypy.patch
     - 2983.patch
+    - 3097.patch
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - 3097.patch
 
 build:
-  number: 1
+  number: 2
 
 outputs:
   - name: {{ namecxx }}


### PR DESCRIPTION
Fix https://github.com/conda-forge/yarp-feedstock/issues/42 .


Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
