### PR TITLE
Enable ACE dependency on osx-arm64

### DIFF
--- a/recipe/build_cxx.sh
+++ b/recipe/build_cxx.sh
@@ -17,12 +17,6 @@ if [[ "${target_platform}" == osx-* ]]; then
     CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
 fi
 
-# On osx-arm64, we do not have ACE
-# See https://github.com/conda-forge/ace-feedstock/issues/29
-if [[ "${target_platform}" == "osx-arm64" ]]; then
-  export CMAKE_ARGS="${CMAKE_ARGS} -DSKIP_ACE:BOOL=ON"
-fi
-
 mkdir build
 cd build
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
     - 3109bis.patch
 
 build:
-  number: 4
+  number: 5
 
 outputs:
   - name: {{ namecxx }}
@@ -49,7 +49,7 @@ outputs:
         - ycm-cmake-modules
 
       host:
-        - ace  # [not osx or not arm64]
+        - ace
         - tinyxml
         - eigen
         - sdl


### PR DESCRIPTION
As we now have osx-arm64 packages for ace: https://github.com/conda-forge/ace-feedstock/pull/59 . I tested locally and there are no tests regression with respect to the `SKIP_ACE=ON` build.


Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
