### PR TITLE
Add regression test for missing yarp/cv/Cv.h and fix version of OpenCV used for build

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -66,10 +66,13 @@ outputs:
       commands:
         - yarp help
         - test -f ${PREFIX}/include/yarp/os/all.h  # [not win]
+        - test -f ${PREFIX}/include/yarp/cv/Cv.h  # [not win]
         - test -f ${PREFIX}/lib/libYARP_os.so  # [linux]
         - test -f ${PREFIX}/lib/libYARP_os.dylib  # [osx]
         - test -f ${PREFIX}/lib/cmake/YARP_os/YARP_osConfig.cmake  # [not win]
         - if not exist %PREFIX%\\Library\\include\\yarp\\os\\all.h exit 1  # [win]
+        # Regression test for https://github.com/conda-forge/yarp-feedstock/issues/69
+        - if not exist %PREFIX%\\Library\\include\\yarp\\cv\\Cv.h exit 1  # [win]
         - if not exist %PREFIX%\\Library\\lib\\YARP_os.lib exit 1  # [win]
         - if not exist %PREFIX%\\Library\\bin\\YARP_os.dll exit 1  # [win]
         - if not exist %PREFIX%\\Library\\lib\\cmake\\YARP_os\\YARP_osConfig.cmake exit 1  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,6 +52,9 @@ outputs:
         - soxr
         - libedit  # [not win]
         - libopencv
+        # Temporary workaround to avoid to update to vs2022, 
+        # see https://github.com/conda-forge/yarp-feedstock/pull/70#issuecomment-2910021339
+        - libopencv 4.11.0=*_6
         - portaudio
         - qt-main
         - ffmpeg


### PR DESCRIPTION
Fix and add test to prevent https://github.com/conda-forge/yarp-feedstock/issues/69 in the future.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
