### PR TITLE
 Backport swig fixes in 3.12.0

### DIFF
--- a/recipe/3262.patch
+++ b/recipe/3262.patch
@@ -1,0 +1,43 @@
+From 2adde77dde11dbfa86adb53420ed86f3dac682f9 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Bartek=20=C5=81ukawski?= <bwmn.peter@gmail.com>
+Date: Thu, 31 Jul 2025 17:40:40 +0200
+Subject: [PATCH] Register bindings for `yarp::dev::ReturnValue`
+
+---
+ bindings/yarp.i                            | 1 +
+ src/libYARP_dev/src/yarp/dev/ReturnValue.h | 3 ++-
+ 2 files changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/bindings/yarp.i b/bindings/yarp.i
+index 886bf88d27..9c8a45e9dc 100644
+--- a/bindings/yarp.i
++++ b/bindings/yarp.i
+@@ -416,6 +416,7 @@ void setExternal2(yarp::sig::Image *img, PyObject* mem, int w, int h) {
+ %include <yarp/dev/DeviceDriver.h>
+ %include <yarp/dev/PolyDriver.h>
+ %include <yarp/dev/Drivers.h>
++%include <yarp/dev/ReturnValue.h>
+ %include <yarp/dev/IFrameGrabberImage.h>
+ %include <yarp/dev/IFrameGrabberControls.h>
+ %include <yarp/dev/IFrameGrabberControlsDC1394.h>
+diff --git a/src/libYARP_dev/src/yarp/dev/ReturnValue.h b/src/libYARP_dev/src/yarp/dev/ReturnValue.h
+index f9971d458c..4c107f7b46 100644
+--- a/src/libYARP_dev/src/yarp/dev/ReturnValue.h
++++ b/src/libYARP_dev/src/yarp/dev/ReturnValue.h
+@@ -74,6 +74,7 @@ class YARP_dev_API ReturnValue : public yarp::os::Portable
+     bool write(yarp::os::ConnectionWriter& connection) const override;
+ };
+ 
++#ifndef SWIG_PREPROCESSOR_SHOULD_SKIP_THIS
+ #define ReturnValue_ok ReturnValue(yarp::dev::ReturnValue::return_code::return_value_ok)
+ 
+ #if __cplusplus >= 202002L
+@@ -101,7 +102,7 @@ inline ReturnValue yarp_method_deprecated(const char* location)
+ }
+ #define YARP_METHOD_DEPRECATED() yarp_method_deprecated(__func__)
+ #endif
+-
++#endif // SWIG_PREPROCESSOR_SHOULD_SKIP_THIS
+ 
+ }
+ 

--- a/recipe/3271.patch
+++ b/recipe/3271.patch
@@ -1,0 +1,43 @@
+From 73b0a806e6353778b262314a779512b33c3d84a5 Mon Sep 17 00:00:00 2001
+From: Marco Randazzo <marco.randazzo@iit.it>
+Date: Wed, 13 Aug 2025 18:01:52 +0200
+Subject: [PATCH] added IJointCoupling interface to bindings
+
+---
+ bindings/yarp.i                                       | 2 ++
+ src/libYARP_dev/src/yarp/dev/ControlBoardInterfaces.h | 1 +
+ 2 files changed, 3 insertions(+)
+
+diff --git a/bindings/yarp.i b/bindings/yarp.i
+index 3a571245116..9fe2fb57455 100644
+--- a/bindings/yarp.i
++++ b/bindings/yarp.i
+@@ -436,6 +436,7 @@ void setExternal2(yarp::sig::Image *img, PyObject* mem, int w, int h) {
+ %include <yarp/dev/ControlBoardPid.h>
+ %include <yarp/dev/IControlMode.h>
+ %include <yarp/dev/IInteractionMode.h>
++%include <yarp/dev/IJointCoupling.h>
+ %include <yarp/dev/IJointFault.h>
+ %include <yarp/dev/IEncodersTimed.h>
+ %include <yarp/dev/IMotor.h>
+@@ -720,6 +721,7 @@ MAKE_COMMS  (Sound, yarp::sig::Sound)
+     CAST_POLYDRIVER_TO_INTERFACE(IImpedanceControl)
+     CAST_POLYDRIVER_TO_INTERFACE(ITorqueControl)
+     CAST_POLYDRIVER_TO_INTERFACE(IControlMode)
++    CAST_POLYDRIVER_TO_INTERFACE(IJointCoupling)
+     CAST_POLYDRIVER_TO_INTERFACE(IJointFault)
+     CAST_POLYDRIVER_TO_INTERFACE(IInteractionMode)
+     CAST_POLYDRIVER_TO_INTERFACE(IPWMControl)
+diff --git a/src/libYARP_dev/src/yarp/dev/ControlBoardInterfaces.h b/src/libYARP_dev/src/yarp/dev/ControlBoardInterfaces.h
+index 426888457f6..d822a963ee6 100644
+--- a/src/libYARP_dev/src/yarp/dev/ControlBoardInterfaces.h
++++ b/src/libYARP_dev/src/yarp/dev/ControlBoardInterfaces.h
+@@ -36,6 +36,7 @@
+ #include <yarp/dev/IAxisInfo.h>
+ #include <yarp/dev/IControlLimits.h>
+ #include <yarp/dev/IControlMode.h>
++#include <yarp/dev/IJointCoupling.h>
+ #include <yarp/dev/IJointFault.h>
+ 
+ #include <yarp/dev/ControlBoardVocabs.h>
+

--- a/recipe/3272.patch
+++ b/recipe/3272.patch
@@ -1,0 +1,51 @@
+From 57c5f496c71e4dd052f17a9881c7cf84841a27d8 Mon Sep 17 00:00:00 2001
+From: Pasquale <pasquale.marra.pro@gmail.com>
+Date: Mon, 18 Aug 2025 16:39:11 +0200
+Subject: [PATCH] Expand
+ https://github.com/robotology/yarp/pull/3271#issue-3319021964
+
+---
+ bindings/yarp.i | 30 ++++++++++++++++++++++++++++++
+ 1 file changed, 30 insertions(+)
+
+diff --git a/bindings/yarp.i b/bindings/yarp.i
+index 9fe2fb5745..dc30d7611a 100644
+--- a/bindings/yarp.i
++++ b/bindings/yarp.i
+@@ -1138,6 +1138,36 @@ MAKE_COMMS  (Sound, yarp::sig::Sound)
+     }
+ }
+ 
++%extend yarp::dev::IJointCoupling {
++    size_t getNrOfPhysicalJoints() {
++        size_t nrOfPhysicalJoints;
++        bool ok = self->getNrOfPhysicalJoints(nrOfPhysicalJoints);
++        if (!ok) return 0;
++        return nrOfPhysicalJoints;
++    }
++
++    size_t getNrOfActuatedAxes() {
++        size_t nrOfActuatedAxes;
++        bool ok = self->getNrOfActuatedAxes(nrOfActuatedAxes);
++        if (!ok) return 0;
++        return nrOfActuatedAxes;
++    }
++
++    std::string getActuatedAxisName(size_t actuatedAxisIndex) {
++        std::string actuatedAxisName;
++        bool ok = self->getActuatedAxisName(actuatedAxisIndex, actuatedAxisName);
++        if (!ok) return "unknown";
++        return actuatedAxisName;
++    }
++
++    std::string getPhysicalJointName(size_t physicalJointIndex) {
++        std::string physicalJointName;
++        bool ok = self->getPhysicalJointName(physicalJointIndex, physicalJointName);
++        if (!ok) return "unknown";
++        return physicalJointName;
++    }
++}
++
+ %extend yarp::dev::IControlMode {
+     int getControlMode(int j) {
+         int buffer;

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,7 @@ source:
   patches:
     - 2983.patch
     - 3262.patch
+    - 3271.patch
     - 3272.patch
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,10 +12,10 @@ source:
   sha256: b8369cb191ef992ef5d806376e3860a1b14b5757e33a6c1608ae99505a5cd5be
   patches:
     - 2983.patch
+    - 3262.patch
 
 build:
-  number: 4
-
+  number: 5
 outputs:
   - name: {{ namecxx }}
     script: build_cxx.sh  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,7 @@ source:
   patches:
     - 2983.patch
     - 3262.patch
+    - 3272.patch
 
 build:
   number: 5


### PR DESCRIPTION
While we wait for 3.12.1, we can backport to the conda-forge builds of YARP the fix https://github.com/robotology/yarp/pull/3262, as requested by @steb6 .


Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
