### PR TITLE
Fix linker error for IJacobianCoupling on Windows 

### DIFF
--- a/recipe/3279.patch
+++ b/recipe/3279.patch
@@ -1,0 +1,52 @@
+From 3b9e5f2cefbf7a7509db86343ed65bc87c248919 Mon Sep 17 00:00:00 2001
+From: Nicogene <nicolo.genesio@iit.it>
+Date: Wed, 27 Aug 2025 12:03:11 +0200
+Subject: [PATCH] IJacobianCoupling: fix linker error under windows
+
+It needs the destructor definition in the .cpp. It fixes #3278
+---
+ src/libYARP_dev/src/CMakeLists.txt                 | 1 +
+ src/libYARP_dev/src/yarp/dev/IJacobianCoupling.cpp | 8 ++++++++
+ src/libYARP_dev/src/yarp/dev/IJacobianCoupling.h   | 2 +-
+ 3 files changed, 10 insertions(+), 1 deletion(-)
+ create mode 100644 src/libYARP_dev/src/yarp/dev/IJacobianCoupling.cpp
+
+diff --git a/src/libYARP_dev/src/CMakeLists.txt b/src/libYARP_dev/src/CMakeLists.txt
+index 043bee43a1..6d8c6c6763 100644
+--- a/src/libYARP_dev/src/CMakeLists.txt
++++ b/src/libYARP_dev/src/CMakeLists.txt
+@@ -173,6 +173,7 @@ set(YARP_dev_SRCS
+   yarp/dev/IFrameWriterAudioVisual.cpp
+   yarp/dev/IFrameWriterImage.cpp
+   yarp/dev/IGenericSensor.cpp
++  yarp/dev/IJacobianCoupling.cpp
+   yarp/dev/IJoypadController.cpp
+   yarp/dev/ILLM.cpp
+   yarp/dev/IMultipleWrapper.cpp
+diff --git a/src/libYARP_dev/src/yarp/dev/IJacobianCoupling.cpp b/src/libYARP_dev/src/yarp/dev/IJacobianCoupling.cpp
+new file mode 100644
+index 0000000000..33ddca91f4
+--- /dev/null
++++ b/src/libYARP_dev/src/yarp/dev/IJacobianCoupling.cpp
+@@ -0,0 +1,8 @@
++/*
++ * SPDX-FileCopyrightText: 2006-2023 Istituto Italiano di Tecnologia (IIT)
++ * SPDX-License-Identifier: BSD-3-Clause
++ */
++
++#include <yarp/dev/IJacobianCoupling.h>
++
++yarp::dev::IJacobianCoupling::~IJacobianCoupling() = default;
+diff --git a/src/libYARP_dev/src/yarp/dev/IJacobianCoupling.h b/src/libYARP_dev/src/yarp/dev/IJacobianCoupling.h
+index 5436730d6a..9e4b94aef1 100644
+--- a/src/libYARP_dev/src/yarp/dev/IJacobianCoupling.h
++++ b/src/libYARP_dev/src/yarp/dev/IJacobianCoupling.h
+@@ -63,7 +63,7 @@ class YARP_dev_API yarp::dev::IJacobianCoupling
+     /**
+      * Destructor.
+      */
+-    virtual ~IJacobianCoupling() {}
++    virtual ~IJacobianCoupling();
+ 
+     /**
+      * @brief Get the Jacobian mapping the Actuated Axes to Physical Joints velocity

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -14,11 +14,12 @@ source:
     patches:
       - 2983.patch
       - 3277.patch
+      - 3279.patch
       # Skip as it is problematic in cross-compilation
       - skip_yarp_generate_device_param_parser_tests.patch
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - package:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
